### PR TITLE
Enhance bot functionality with Whisper HTTP client for speech-to-text

### DIFF
--- a/bot/bot.go
+++ b/bot/bot.go
@@ -3,6 +3,9 @@ package bot
 import (
 	"context"
 	"fmt"
+	"io"
+	"net/http"
+	"os"
 	"time"
 
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
@@ -29,6 +32,8 @@ type ExtendedBotAPI interface {
 	SendVideo(ctx context.Context, chatID int64, fileID string, caption string) (*tgbotapi.Message, error)
 	EditMessageText(ctx context.Context, chatID int64, messageID int, text string, replyMarkup *tgbotapi.InlineKeyboardMarkup) (*tgbotapi.Message, error)
 	AnswerCallbackQuery(ctx context.Context, queryID string, text string, showAlert bool) error
+	GetFile(ctx context.Context, fileID string) (*tgbotapi.File, error)
+	DownloadFile(ctx context.Context, filePath string, destPath string) error
 }
 
 type Bot struct {
@@ -113,7 +118,7 @@ func (b *Bot) HandleCommand(ctx context.Context, msg *tgbotapi.Message, msgIDs [
 		}
 		return answer, nil
 	case "start":
-		message := tgbotapi.NewMessage(chatID, fmt.Sprint("Привет! Задавай мне вопросы, а постараюсь ответить на них правильно! (на базе DeepSeek v3)"))
+		message := tgbotapi.NewMessage(chatID, "Привет! Задавай мне вопросы, а постараюсь ответить на них правильно! (на базе DeepSeek v3)")
 		message.ReplyMarkup = buttons.InitKeyboard()
 
 		send, err := b.api.Send(message)
@@ -233,5 +238,59 @@ func (b *Bot) AnswerCallbackQuery(ctx context.Context, queryID string, text stri
 	if err != nil {
 		return fmt.Errorf("answer callback query: %w", err)
 	}
+	return nil
+}
+
+// GetFile получает информацию о файле по fileID
+func (b *Bot) GetFile(ctx context.Context, fileID string) (*tgbotapi.File, error) {
+	file, err := b.api.GetFile(tgbotapi.FileConfig{FileID: fileID})
+	if err != nil {
+		return nil, fmt.Errorf("get file: %w", err)
+	}
+	return &file, nil
+}
+
+// DownloadFile скачивает файл из Telegram по filePath
+func (b *Bot) DownloadFile(ctx context.Context, filePath string, destPath string) error {
+	url, err := b.api.GetFileDirectURL(filePath)
+	if err != nil {
+		return fmt.Errorf("get file URL: %w", err)
+	}
+
+	// Создаем HTTP запрос
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("create request: %w", err)
+	}
+
+	// Выполняем запрос
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("download file: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download file: status code %d", resp.StatusCode)
+	}
+
+	// Создаем файл для записи
+	outFile, err := os.Create(destPath)
+	if err != nil {
+		return fmt.Errorf("create file: %w", err)
+	}
+	defer outFile.Close()
+
+	// Копируем данные
+	_, err = io.Copy(outFile, resp.Body)
+	if err != nil {
+		return fmt.Errorf("copy file: %w", err)
+	}
+
+	b.logger.Debugw("File downloaded",
+		"file_path", filePath,
+		"dest_path", destPath,
+	)
 	return nil
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -69,7 +69,7 @@ func main() {
 
 	// Инициализация сервисов
 	aiService := services.NewAIService(r1, sugaredLogger)
-	speechToTextService := services.NewSpeechToTextServiceStub() // Заглушка
+	speechToTextService := services.NewWhisperHTTPClient(b, botCfg, sugaredLogger)
 	dialogHistoryService := services.NewDialogHistoryService(pool, redisClient, sugaredLogger)
 	userRepository := services.NewUserRepository(pool, sugaredLogger)
 

--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,8 @@ type Config struct {
 	RedisAddr          string
 	RedisPassword      string
 	RedisDB            int
+	WhisperServiceURL  string
+	TempDir            string
 }
 
 type Logger struct {
@@ -111,6 +113,8 @@ func LoadEnvCfg(source string) (*Config, error) {
 		RedisAddr:          os.Getenv("REDIS_ADDR"),
 		RedisPassword:      os.Getenv("REDIS_PASSWORD"),
 		RedisDB:            parsedRedisDB,
+		WhisperServiceURL:  os.Getenv("WHISPER_SERVICE_URL"),
+		TempDir:            getEnvOrDefault("TEMP_DIR", "/tmp"),
 		Logger: Logger{
 			Development:      logDevelopment,
 			OutputPaths:      strings.Split(os.Getenv("LOG_OUTPUT_PATHS"), ","),
@@ -118,4 +122,13 @@ func LoadEnvCfg(source string) (*Config, error) {
 		},
 	}
 	return cfg, nil
+}
+
+// getEnvOrDefault возвращает значение переменной окружения или значение по умолчанию
+func getEnvOrDefault(key, defaultValue string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	return value
 }

--- a/internal/services/speech_to_text.go
+++ b/internal/services/speech_to_text.go
@@ -1,13 +1,236 @@
 package services
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/vlks-dev/mytelegrambotapi/bot"
+	"github.com/vlks-dev/mytelegrambotapi/config"
+	"go.uber.org/zap"
 )
 
 // SpeechToTextService интерфейс для преобразования речи в текст
 type SpeechToTextService interface {
 	// Transcribe преобразует голосовое сообщение в текст
 	Transcribe(ctx context.Context, fileID string) (string, error)
+}
+
+// whisperHTTPClient реализация SpeechToTextService через Whisper HTTP сервис
+type whisperHTTPClient struct {
+	botAPI            bot.ExtendedBotAPI
+	whisperServiceURL string
+	tempDir           string
+	httpClient        *http.Client
+	logger            *zap.SugaredLogger
+}
+
+// NewWhisperHTTPClient создает новый Whisper HTTP клиент
+func NewWhisperHTTPClient(botAPI bot.ExtendedBotAPI, cfg *config.Config, logger *zap.SugaredLogger) SpeechToTextService {
+	if cfg.WhisperServiceURL == "" {
+		logger.Warn("Whisper service URL not configured, using stub")
+		return NewSpeechToTextServiceStub()
+	}
+
+	return &whisperHTTPClient{
+		botAPI:            botAPI,
+		whisperServiceURL: cfg.WhisperServiceURL,
+		tempDir:           cfg.TempDir,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+		logger: logger.Named("whisper_client"),
+	}
+}
+
+// Transcribe преобразует голосовое сообщение в текст
+func (s *whisperHTTPClient) Transcribe(ctx context.Context, fileID string) (string, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	s.logger.Debugw("Starting transcription",
+		"file_id", fileID,
+	)
+
+	// Шаг 1: Получаем информацию о файле
+	file, err := s.botAPI.GetFile(ctx, fileID)
+	if err != nil {
+		return "", fmt.Errorf("get file info: %w", err)
+	}
+
+	// Шаг 2: Скачиваем файл
+	if file.FilePath == "" {
+		return "", fmt.Errorf("file path is empty for file_id: %s", fileID)
+	}
+	originalPath := filepath.Join(s.tempDir, fmt.Sprintf("voice_%s_%d.ogg", fileID, time.Now().Unix()))
+	err = s.botAPI.DownloadFile(ctx, file.FilePath, originalPath)
+	if err != nil {
+		return "", fmt.Errorf("download file: %w", err)
+	}
+	defer os.Remove(originalPath)
+
+	s.logger.Debugw("File downloaded",
+		"file_id", fileID,
+		"path", originalPath,
+	)
+
+	// Шаг 3: Конвертируем в WAV (если нужно)
+	wavPath := filepath.Join(s.tempDir, fmt.Sprintf("voice_%s_%d.wav", fileID, time.Now().Unix()))
+	err = s.convertToWAV(ctx, originalPath, wavPath)
+	if err != nil {
+		s.logger.Warnw("Failed to convert to WAV, trying original file",
+			"error", err,
+		)
+		// Пробуем отправить оригинальный файл
+		wavPath = originalPath
+	} else {
+		defer os.Remove(wavPath)
+	}
+
+	// Шаг 4: Отправляем в Whisper сервис с retry
+	var transcription string
+	maxRetries := 2
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			s.logger.Infow("Retrying transcription",
+				"attempt", attempt+1,
+				"file_id", fileID,
+			)
+			time.Sleep(time.Duration(attempt) * time.Second)
+		}
+
+		transcription, err = s.sendToWhisper(ctx, wavPath)
+		if err == nil {
+			break
+		}
+
+		if ctx.Err() != nil {
+			return "", fmt.Errorf("context deadline exceeded: %w", ctx.Err())
+		}
+
+		s.logger.Warnw("Transcription attempt failed",
+			"attempt", attempt+1,
+			"error", err,
+		)
+	}
+
+	if err != nil {
+		return "", fmt.Errorf("transcription failed after %d attempts: %w", maxRetries+1, err)
+	}
+
+	s.logger.Debugw("Transcription completed",
+		"file_id", fileID,
+		"text_length", len(transcription),
+	)
+
+	return transcription, nil
+}
+
+// convertToWAV конвертирует аудио файл в WAV формат используя ffmpeg
+func (s *whisperHTTPClient) convertToWAV(ctx context.Context, inputPath, outputPath string) error {
+	// Проверяем, что ffmpeg доступен
+	_, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		return fmt.Errorf("ffmpeg not found: %w", err)
+	}
+
+	// Конвертируем: OGG/OPUS -> WAV (16kHz, моно)
+	cmd := exec.CommandContext(ctx, "ffmpeg",
+		"-i", inputPath,
+		"-ar", "16000", // Sample rate 16kHz
+		"-ac", "1", // Mono channel
+		"-y", // Overwrite output file
+		outputPath,
+	)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("ffmpeg conversion failed: %w, stderr: %s", err, stderr.String())
+	}
+
+	s.logger.Debugw("Audio converted to WAV",
+		"input", inputPath,
+		"output", outputPath,
+	)
+	return nil
+}
+
+// sendToWhisper отправляет файл в Whisper сервис
+func (s *whisperHTTPClient) sendToWhisper(ctx context.Context, filePath string) (string, error) {
+	// Открываем файл
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("open file: %w", err)
+	}
+	defer file.Close()
+
+	// Создаем multipart form
+	var requestBody bytes.Buffer
+	writer := multipart.NewWriter(&requestBody)
+
+	// Добавляем файл
+	part, err := writer.CreateFormFile("audio", filepath.Base(filePath))
+	if err != nil {
+		return "", fmt.Errorf("create form file: %w", err)
+	}
+
+	_, err = io.Copy(part, file)
+	if err != nil {
+		return "", fmt.Errorf("copy file to form: %w", err)
+	}
+
+	err = writer.Close()
+	if err != nil {
+		return "", fmt.Errorf("close writer: %w", err)
+	}
+
+	// Создаем HTTP запрос
+	req, err := http.NewRequestWithContext(ctx, "POST", s.whisperServiceURL+"/transcribe", &requestBody)
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	// Выполняем запрос
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Проверяем статус
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("whisper service error: status %d, body: %s", resp.StatusCode, string(body))
+	}
+
+	// Парсим ответ
+	var response struct {
+		Text string `json:"text"`
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	if err != nil {
+		return "", fmt.Errorf("decode response: %w", err)
+	}
+
+	if response.Text == "" {
+		return "", fmt.Errorf("empty transcription result")
+	}
+
+	return response.Text, nil
 }
 
 // speechToTextServiceStub заглушка реализации SpeechToTextService
@@ -22,4 +245,3 @@ func NewSpeechToTextServiceStub() SpeechToTextService {
 func (s *speechToTextServiceStub) Transcribe(ctx context.Context, fileID string) (string, error) {
 	return "заглушка для голосового сообщения", nil
 }
-


### PR DESCRIPTION
- Added `GetFile` and `DownloadFile` methods to the bot API for file handling.
- Implemented `whisperHTTPClient` for speech-to-text service using Whisper API.
- Refactored `main.go` to initialize the new Whisper HTTP client.
- Extended configuration to support Whisper service URL and temporary directory settings.
- Improved error handling and logging throughout the new speech-to-text implementation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integrates a Whisper-based speech-to-text client, extends the bot API for Telegram file retrieval, and wires configuration and main to enable voice transcription.
> 
> - **Services (`internal/services/speech_to_text.go`)**:
>   - **Whisper STT client**: New `whisperHTTPClient` implementing `SpeechToTextService`.
>     - Downloads Telegram audio via `GetFile`/`DownloadFile`, converts to WAV with `ffmpeg`, sends multipart to `POST /transcribe`, retries, and logs.
>     - Falls back to stub when `WHISPER_SERVICE_URL` is unset.
> - **Bot API (`bot/bot.go`)**:
>   - Extend `ExtendedBotAPI` with `GetFile` and `DownloadFile` and implement both (HTTP download using Telegram direct URL).
> - **Config (`config/config.go`)**:
>   - Add `WhisperServiceURL` and `TempDir`; include helper `getEnvOrDefault` and env wiring.
> - **Main (`cmd/main.go`)**:
>   - Replace STT stub with `services.NewWhisperHTTPClient` and wire into voice processing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7fe2d15fdc1f08732fa1b64627e0056ee692ecd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->